### PR TITLE
Remove monad fail

### DIFF
--- a/library/Recurlude.hs
+++ b/library/Recurlude.hs
@@ -16,6 +16,7 @@ module Recurlude
   , module Network.HTTP.Types
   , module Network.URI
   , module Numeric.Natural
+  , module Recurlude.WithCallStack
   , module Witch
   -- IO
   , Moon
@@ -55,6 +56,7 @@ import Network.HTTP.Types
   (HeaderName, Method, methodDelete, methodGet, methodPost, methodPut, statusCode)
 import Network.URI (URI)
 import Numeric.Natural (Natural)
+import Recurlude.WithCallStack
 import Witch (From(..), TryFrom(..), into, maybeTryFrom, tryInto, via)
 
 import qualified Data.Aeson as Aeson

--- a/library/Recurlude/WithCallStack.hs
+++ b/library/Recurlude/WithCallStack.hs
@@ -1,0 +1,62 @@
+module Recurlude.WithCallStack where
+
+import Control.Exception (Exception(..), SomeException(..), throw)
+import Control.Monad.Catch (MonadThrow)
+import GHC.Stack
+  ( CallStack
+  , HasCallStack
+  , callStack
+  , emptyCallStack
+  , fromCallSiteList
+  , getCallStack
+  , prettyCallStack
+  )
+import Prelude
+
+-- | This data type represents an exception along with a call stack. It is
+-- assumed that the call stack comes from where the exception was thrown, but
+-- that may not always be the case.
+data WithCallStack = WithCallStack SomeException CallStack
+  deriving Show
+
+instance Exception WithCallStack where
+  displayException (WithCallStack (SomeException e) s) =
+    unlines [displayException e, prettyCallStack s]
+
+appendCallStacks :: CallStack -> CallStack -> CallStack
+appendCallStacks x y = fromCallSiteList $ getCallStack x <> getCallStack y
+
+-- | Adds a call stack to some exception. If the exception already has a call
+-- stack, the current call stack will be appended to it.
+addCallStack :: HasCallStack => SomeException -> SomeException
+addCallStack e1 = toException $ case fromException e1 of
+  Just (WithCallStack e2 s) -> WithCallStack e2 $ appendCallStacks callStack s
+  Nothing -> WithCallStack e1 callStack
+
+-- | Extracts the call stack from some exception. If the exception was a
+-- 'WithCallStack', that layer will be stripped off. If there was no call
+-- stack, that part will be 'emptyCallStack'. If there were multiple call
+-- stacks, they will be appended.
+extractCallStack :: SomeException -> (SomeException, CallStack)
+extractCallStack e1 = case fromException e1 of
+  Just (WithCallStack e2 s) -> fmap (flip appendCallStacks s) $ extractCallStack e2
+  Nothing -> (e1, emptyCallStack)
+
+-- | Removes the call stack from some exception. If the exception didn't have a
+-- call stack, it is returned unchanged.
+removeCallStack :: SomeException -> SomeException
+removeCallStack = fst . extractCallStack
+
+-- | Attachs a call stack to an exception and then throws it. When possible you
+-- should prefer this function over @throwIO@ and @throw@.
+throwWithCallStack :: (HasCallStack, Exception e, MonadThrow m) => e -> m a
+throwWithCallStack = throw . addCallStack . toException
+
+castException :: Exception e => SomeException -> Maybe e
+castException = fromException . removeCallStack
+
+eitherThrow :: (HasCallStack, Exception e, MonadThrow m) => Either e a -> m a
+eitherThrow = eitherThrowWith id
+
+eitherThrowWith :: (HasCallStack, Exception e2, MonadThrow m) => (e1 -> e2) -> Either e1 a -> m a
+eitherThrowWith f = either (throwWithCallStack . f) pure

--- a/library/Recurly/V3/API/Account.hs
+++ b/library/Recurly/V3/API/Account.hs
@@ -15,13 +15,13 @@ import Recurly.V3.API.Types.PostAccountLineItem (PostAccountLineItem)
 import Recurly.V3.API.Types.PutAccount (PutAccount)
 import Recurly.V3.API.Types.Subscription (Subscription)
 import qualified Recurly.V3.Http as RecurlyApi
-import Recurly.V3.Http (RecurlyError)
 import qualified Recurly.V3.Recurly as Recurly
+import Recurly.V3.Types.RecurlyException (RecurlyException)
 
 getAccountSubscriptions
   :: Recurly.MonadRecurly m
   => Account.Code
-  -> m (Client.Response (Either RecurlyError [Subscription]))
+  -> m (Client.Response (Either RecurlyException [Subscription]))
 getAccountSubscriptions accountCode = Recurly.liftRecurly $ do
   request <- RecurlyApi.makeRequest
     ["accounts", into @PathPiece.PathPiece accountCode, "subscriptions"]
@@ -30,7 +30,7 @@ getAccountSubscriptions accountCode = Recurly.liftRecurly $ do
 getAccountCouponRedemptions
   :: Recurly.MonadRecurly m
   => Account.Code
-  -> m (Client.Response (Either RecurlyError [AccountCouponRedemption]))
+  -> m (Client.Response (Either RecurlyException [AccountCouponRedemption]))
 getAccountCouponRedemptions accountCode = Recurly.liftRecurly $ do
   request <- RecurlyApi.makeRequest
     ["accounts", into @PathPiece.PathPiece accountCode, "coupon_redemptions"]
@@ -39,13 +39,13 @@ getAccountCouponRedemptions accountCode = Recurly.liftRecurly $ do
 getActiveAccountCouponRedemption
   :: Recurly.MonadRecurly m
   => Account.Code
-  -> m (Client.Response (Either RecurlyError [AccountCouponRedemption]))
+  -> m (Client.Response (Either RecurlyException [AccountCouponRedemption]))
 getActiveAccountCouponRedemption accountCode = Recurly.liftRecurly $ do
   request <- RecurlyApi.makeRequest
     ["accounts", into @PathPiece.PathPiece accountCode, "coupon_redemptions", "active"]
   RecurlyApi.sendRequestList request
 
-postAccount :: PostAccount -> Recurly.Recurly (Client.Response (Either RecurlyError Account))
+postAccount :: PostAccount -> Recurly.Recurly (Client.Response (Either RecurlyException Account))
 postAccount account = do
   request <- RecurlyApi.makeRequest ["accounts"]
   RecurlyApi.sendRequest request
@@ -57,7 +57,7 @@ putAccount
   :: Recurly.MonadRecurly m
   => Account.Code
   -> PutAccount
-  -> m (Client.Response (Either RecurlyError Account))
+  -> m (Client.Response (Either RecurlyException Account))
 putAccount accountCode account = Recurly.liftRecurly $ do
   request <- RecurlyApi.makeRequest ["accounts", into @PathPiece.PathPiece accountCode]
   RecurlyApi.sendRequest request
@@ -68,7 +68,7 @@ putAccount accountCode account = Recurly.liftRecurly $ do
 postAccountLineItem
   :: Account.Code
   -> PostAccountLineItem
-  -> Recurly.Recurly (Client.Response (Either RecurlyError AccountLineItem))
+  -> Recurly.Recurly (Client.Response (Either RecurlyException AccountLineItem))
 postAccountLineItem accountCode accountLineItem = do
   request <- RecurlyApi.makeRequest
     ["accounts", into @PathPiece.PathPiece accountCode, "line_items"]
@@ -80,7 +80,7 @@ postAccountLineItem accountCode accountLineItem = do
 deleteActiveCouponRedemptions
   :: Recurly.MonadRecurly m
   => Account.Code
-  -> m (Client.Response (Either RecurlyError AccountCouponRedemption))
+  -> m (Client.Response (Either RecurlyException AccountCouponRedemption))
 deleteActiveCouponRedemptions accountCode = Recurly.liftRecurly $ do
   request <- RecurlyApi.makeRequest
     ["accounts", into @PathPiece.PathPiece accountCode, "coupon_redemptions", "active"]

--- a/library/Recurly/V3/API/Coupon.hs
+++ b/library/Recurly/V3/API/Coupon.hs
@@ -8,10 +8,10 @@ import qualified Network.HTTP.Client as Client
 import Recurly.V3.API.Types.Coupon (Coupon)
 import Recurly.V3.API.Types.PostCoupon (PostCoupon)
 import qualified Recurly.V3.Http as RecurlyApi
-import Recurly.V3.Http (RecurlyError)
 import qualified Recurly.V3.Recurly as Recurly
+import Recurly.V3.Types.RecurlyException (RecurlyException)
 
-postCoupon :: PostCoupon -> Recurly.Recurly (Client.Response (Either RecurlyError Coupon))
+postCoupon :: PostCoupon -> Recurly.Recurly (Client.Response (Either RecurlyException Coupon))
 postCoupon coupon = do
   request <- RecurlyApi.makeRequest ["coupons"]
   RecurlyApi.sendRequest request

--- a/library/Recurly/V3/API/Invoice.hs
+++ b/library/Recurly/V3/API/Invoice.hs
@@ -8,11 +8,12 @@ import qualified Network.HTTP.Client as Client
 import qualified Recurly.V3.API.Types.Invoice as Invoice
 import qualified Recurly.V3.API.Types.PathPiece as PathPiece
 import qualified Recurly.V3.Http as RecurlyApi
-import Recurly.V3.Http (RecurlyError)
 import qualified Recurly.V3.Recurly as Recurly
+import Recurly.V3.Types.RecurlyException (RecurlyException)
 
 getInvoicePdf
-  :: Invoice.Id -> Recurly.Recurly (Client.Response (Either RecurlyError LazyByteString.ByteString))
+  :: Invoice.Id
+  -> Recurly.Recurly (Client.Response (Either RecurlyException LazyByteString.ByteString))
 getInvoicePdf invoiceId = do
   let rawInvoiceId = PathPiece.PathPiece $ into @Text invoiceId
   request <- RecurlyApi.makeRequest ["invoices", rawInvoiceId <> ".pdf"]

--- a/library/Recurly/V3/API/Subscription.hs
+++ b/library/Recurly/V3/API/Subscription.hs
@@ -9,11 +9,11 @@ import qualified Recurly.V3.API.Types.PathPiece as PathPiece
 import Recurly.V3.API.Types.Subscription (Subscription)
 import qualified Recurly.V3.API.Types.Subscription as Subscription
 import qualified Recurly.V3.Http as RecurlyApi
-import Recurly.V3.Http (RecurlyError)
 import qualified Recurly.V3.Recurly as Recurly
+import Recurly.V3.Types.RecurlyException (RecurlyException)
 
 getSubscription
-  :: Subscription.Uuid -> Recurly.Recurly (Client.Response (Either RecurlyError Subscription))
+  :: Subscription.Uuid -> Recurly.Recurly (Client.Response (Either RecurlyException Subscription))
 getSubscription subscriptionUuid = do
   request <- RecurlyApi.makeRequest ["subscriptions", into @PathPiece.PathPiece subscriptionUuid]
   RecurlyApi.sendRequest request
@@ -21,7 +21,7 @@ getSubscription subscriptionUuid = do
 getSubscriptionInvoices
   :: Recurly.MonadRecurly m
   => Subscription.Uuid
-  -> m (Client.Response (Either RecurlyError [Invoice]))
+  -> m (Client.Response (Either RecurlyException [Invoice]))
 getSubscriptionInvoices subscriptionUuid = Recurly.liftRecurly $ do
   request <- RecurlyApi.makeRequest
     ["subscriptions", into @PathPiece.PathPiece subscriptionUuid, "invoices"]
@@ -30,7 +30,7 @@ getSubscriptionInvoices subscriptionUuid = Recurly.liftRecurly $ do
 cancelSubscription
   :: Recurly.MonadRecurly m
   => Subscription.Uuid
-  -> m (Client.Response (Either RecurlyError Subscription))
+  -> m (Client.Response (Either RecurlyException Subscription))
 cancelSubscription subscriptionUuid = Recurly.liftRecurly $ do
   request <- RecurlyApi.makeRequest
     ["subscriptions", into @PathPiece.PathPiece subscriptionUuid, "cancel"]

--- a/library/Recurly/V3/Recurly.hs
+++ b/library/Recurly/V3/Recurly.hs
@@ -35,7 +35,6 @@ newtype Recurly result = Recurly
     , Monad
     , Monad.MonadPlus
     , MonadCatch
-    , MonadFail
     , MonadIO
     , MonadThrow
     , Unlift.MonadUnliftIO

--- a/library/Recurly/V3/Types/RecurlyException.hs
+++ b/library/Recurly/V3/Types/RecurlyException.hs
@@ -1,0 +1,101 @@
+module Recurly.V3.Types.RecurlyException where
+
+import Recurlude
+
+import qualified Data.Aeson as Aeson
+import qualified Network.HTTP.Client as Client
+
+data RecurlyException
+  = ApiException RecurlyError
+  | DecodeException ResponseError
+  | ServerErrorException ResponseError
+  | HttpException HttpError
+    deriving Show
+
+decode :: Text -> Text -> Client.Request -> RecurlyException
+decode msg body req = DecodeException $ ResponseError msg body req
+
+serverError :: Text -> Text -> Client.Request -> RecurlyException
+serverError msg body req = ServerErrorException $ ResponseError msg body req
+
+http :: Text -> Client.HttpException -> Client.Request -> RecurlyException
+http msg exception req = HttpException $ HttpError msg exception req
+
+data ResponseError = ResponseError
+  { responseErrorMessage :: Text
+  , responseErrorResponseBody :: Text
+  , responseErrorRequest :: Client.Request
+  }
+  deriving Show
+
+data HttpError = HttpError
+  { httpErrorMessage :: Text
+  , httpErrorException :: Client.HttpException
+  , httpErrorRequest :: Client.Request
+  }
+  deriving Show
+
+instance Exception RecurlyException where
+  displayException = pShow
+
+data RecurlyError = RecurlyError
+  { recurlyErrorType :: ErrorType
+  , recurlyErrorMessage :: String
+  , recurlyErrorParams :: Maybe Aeson.Array
+  }
+  deriving Show
+
+instance FromJSON RecurlyError where
+  parseJSON = withObject "RecurlyError" $ \obj -> do
+    err <- aesonRequired obj "error"
+    RecurlyError <$> aesonRequired err "type" <*> aesonRequired err "message" <*> aesonOptional
+      err
+      "params"
+
+data ErrorType
+  = BadRequest
+  | InternalServerError
+  | ImmutableSubscription
+  | InvalidApiKey
+  | InvalidApiVersion
+  | InvalidContentType
+  | InvalidPermissions
+  | InvalidToken
+  | NotFound
+  | SimultaneousRequest
+  | Transaction
+  | Unauthorized
+  | UnavailableInApiVersion
+  | UnknownApiVersion
+  | Validation
+  | MissingFeature
+  | RateLimited
+  | ServiceNotAvailable
+  deriving (Eq, Show)
+
+instance FromJSON ErrorType where
+  parseJSON value = do
+    string <- parseJSON value
+    eitherFail $ stringToErrorType string
+
+stringToErrorType :: String -> Either String ErrorType
+stringToErrorType errorType = case errorType of
+  "bad_request" -> Right BadRequest
+  "internal_server_error" -> Right InternalServerError
+  "immutable_subscription" -> Right ImmutableSubscription
+  "invalid_api_key" -> Right InvalidApiKey
+  "invalid_api_version" -> Right InvalidApiVersion
+  "invalid_content_type" -> Right InvalidContentType
+  "invalid_permissions" -> Right InvalidPermissions
+  "invalid_token" -> Right InvalidToken
+  "not_found" -> Right NotFound
+  "simultaneous_request" -> Right SimultaneousRequest
+  "transaction" -> Right Transaction
+  "unauthorized" -> Right Unauthorized
+  "unavailable_in_api_version" -> Right UnavailableInApiVersion
+  "unknown_api_version" -> Right UnknownApiVersion
+  "validation" -> Right Validation
+  "missing_feature" -> Right MissingFeature
+  "rate_limited" -> Right RateLimited
+  "service_not_available" -> Right ServiceNotAvailable
+  _ -> Left $ "Unknown error type: " <> errorType

--- a/recurly.cabal
+++ b/recurly.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 6c29901b605e9f7b1dafcae5f6507cedfbd1049cc64a7ea0ebb08cb2e28c74d8
+-- hash: 93cec51b0b7b8f0122ddabbc753afe83884a4d784e37f8f2b516d1109c72d9b5
 
 name:           recurly
 version:        0.0.0.1
@@ -25,6 +25,7 @@ source-repository head
 library
   exposed-modules:
       Recurlude
+      Recurlude.WithCallStack
       Recurly.V3.API.Account
       Recurly.V3.API.Coupon
       Recurly.V3.API.Invoice
@@ -179,6 +180,7 @@ library
       Recurly.V3.Env.WebhookUsername
       Recurly.V3.Http
       Recurly.V3.Recurly
+      Recurly.V3.Types.RecurlyException
       Recurly.V3.Webhook.Webhook
   other-modules:
       Paths_recurly

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,6 +1,6 @@
 # https://docs.haskellstack.org/en/stable/yaml_configuration/
 
-resolver: lts-18.6
+resolver: lts-18.10
 
 packages:
   - .

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -6,7 +6,7 @@
 packages: []
 snapshots:
 - completed:
-    size: 587113
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/18/6.yaml
-    sha256: f74c482d7c93739ecf3abfbc0f2dea1c20a2dfb2462c689846ed55a9653b66f7
-  original: lts-18.6
+    size: 587546
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/18/10.yaml
+    sha256: 88b4f81e162ba3adc230a9fcccc4d19ac116377656bab56c7382ca88598b257a
+  original: lts-18.10


### PR DESCRIPTION
Changes:
- Update to LTS 18.10
- Move and split out all types of possible exceptions that can be generated from a recurly api call
- Remove `MonadFail` from `Recurly` monad
  - instead of failing, the exception is overloaded on the existing either return type.
- Throw (with callstack) when the server times out a few times
  - Might be worth removing the call stack stuff and returning the body instead with a timeout ala `ServerError`. Let me know what you think.

---

- [x] I manually tested the code locally to make sure that it works.
- [ ] If there is documentation, I made sure it's accurate and up to date.
- [ ] If possible, I wrote automated tests for the new behavior.
