### PR TITLE
Add call for billing info

### DIFF
--- a/library/Recurly/V3/API/Account.hs
+++ b/library/Recurly/V3/API/Account.hs
@@ -9,6 +9,7 @@ import qualified Recurly.V3.API.Types.Account as Account
 import Recurly.V3.API.Types.Account (Account)
 import Recurly.V3.API.Types.AccountCouponRedemption (AccountCouponRedemption)
 import Recurly.V3.API.Types.AccountLineItem (AccountLineItem)
+import Recurly.V3.API.Types.BillingInfo (BillingInfo)
 import qualified Recurly.V3.API.Types.PathPiece as PathPiece
 import Recurly.V3.API.Types.PostAccount (PostAccount)
 import Recurly.V3.API.Types.PostAccountLineItem (PostAccountLineItem)
@@ -17,6 +18,15 @@ import Recurly.V3.API.Types.Subscription (Subscription)
 import qualified Recurly.V3.Http as RecurlyApi
 import qualified Recurly.V3.Recurly as Recurly
 import Recurly.V3.Types.RecurlyException (RecurlyException)
+
+getAccountBillingInfo
+  :: Recurly.MonadRecurly m
+  => Account.Code
+  -> m (Client.Response (Either RecurlyException BillingInfo))
+getAccountBillingInfo accountCode = Recurly.liftRecurly $ do
+  request <- RecurlyApi.makeRequest
+    ["accounts", into @PathPiece.PathPiece accountCode, "billing_info"]
+  RecurlyApi.sendRequestList request
 
 getAccountSubscriptions
   :: Recurly.MonadRecurly m

--- a/library/Recurly/V3/API/Types/BillingInfo.hs
+++ b/library/Recurly/V3/API/Types/BillingInfo.hs
@@ -1,0 +1,26 @@
+module Recurly.V3.API.Types.BillingInfo
+  ( module Recurly.V3.API.Types.BillingInfo
+  , BillingInfo.PaymentMethod
+  ) where
+
+import Recurlude
+
+import qualified Recurly.V3.API.Types.Account.FirstName as Account
+import qualified Recurly.V3.API.Types.Account.LastName as Account
+import qualified Recurly.V3.API.Types.BillingInfo.PaymentMethod as BillingInfo
+
+data BillingInfo = BillingInfo
+  { id_ :: Text
+  , paymentMethod :: BillingInfo.PaymentMethod
+  , firstName :: Maybe Account.FirstName
+  , lastName :: Maybe Account.LastName
+  }
+  deriving (Eq, Show)
+
+instance FromJSON BillingInfo where
+  parseJSON = withObject "BillingInfo" $ \obj -> do
+    id_ <- aesonRequired obj "id"
+    payment_method <- aesonRequired obj "payment_method"
+    firstName <- aesonOptional obj "first_name"
+    lastName <- aesonOptional obj "last_name"
+    pure BillingInfo { id_, payment_method, firstName, lastName }

--- a/library/Recurly/V3/API/Types/BillingInfo/PaymentMethod.hs
+++ b/library/Recurly/V3/API/Types/BillingInfo/PaymentMethod.hs
@@ -14,6 +14,7 @@ data PaymentMethod = PaymentMethod
   , cardType :: PaymentMethod.CardType
   , lastFour :: Text
   , month :: Integer
+  , year :: Integer
   , payPalBillingAgreementId :: Maybe Text
   }
   deriving (Eq, Show)
@@ -24,5 +25,6 @@ instance FromJSON PaymentMethod where
     cardType <- aesonRequired obj "card_type"
     lastFour <- aesonRequired obj "last_four"
     month <- aesonRequired obj "exp_month"
+    year <- aesonRequired obj "exp_year"
     payPalBillingAgreementId <- aesonOptional obj "billing_agreement_id"
-    pure PaymentMethod { object, cardType, lastFour, month, payPalBillingAgreementId }
+    pure PaymentMethod { object, cardType, lastFour, month, year, payPalBillingAgreementId }

--- a/library/Recurly/V3/API/Types/BillingInfo/PaymentMethod.hs
+++ b/library/Recurly/V3/API/Types/BillingInfo/PaymentMethod.hs
@@ -1,0 +1,28 @@
+module Recurly.V3.API.Types.BillingInfo.PaymentMethod
+  ( module Recurly.V3.API.Types.BillingInfo.PaymentMethod
+  , PaymentMethod.CardType
+  , PaymentMethod.Object
+  ) where
+
+import Recurlude
+
+import qualified Recurly.V3.API.Types.BillingInfo.PaymentMethod.CardType as PaymentMethod
+import qualified Recurly.V3.API.Types.BillingInfo.PaymentMethod.Object as PaymentMethod
+
+data PaymentMethod = PaymentMethod
+  { object :: PaymentMethod.Object
+  , cardType :: PaymentMethod.CardType
+  , lastFour :: Text
+  , month :: Integer
+  , payPalBillingAgreementId :: Maybe Text
+  }
+  deriving (Eq, Show)
+
+instance FromJSON PaymentMethod where
+  parseJSON = withObject "PaymentMethod" $ \obj -> do
+    object <- aesonRequired obj "object"
+    cardType <- aesonRequired obj "card_type"
+    lastFour <- aesonRequired obj "last_four"
+    month <- aesonRequired obj "exp_month"
+    payPalBillingAgreementId <- aesonOptional obj "billing_agreement_id"
+    pure PaymentMethod { object, cardType, lastFour, month, payPalBillingAgreementId }

--- a/library/Recurly/V3/API/Types/BillingInfo/PaymentMethod/CardType.hs
+++ b/library/Recurly/V3/API/Types/BillingInfo/PaymentMethod/CardType.hs
@@ -1,0 +1,61 @@
+module Recurly.V3.API.Types.BillingInfo.PaymentMethod.CardType where
+
+import Recurlude
+
+data CardType
+  = AmericanExpress
+  | Dankort
+  | DinersClub
+  | Discover
+  | Forbrugsforeningen
+  | JCB
+  | Laser
+  | Maestro
+  | MasterCard
+  | TestCard
+  | UnionPay
+  | Unknown
+  | Visa
+  | TarjetaNaranja
+  deriving (Eq, Show)
+
+instance ToJSON CardType where
+  toJSON = toJSON . into @Text
+
+instance FromJSON CardType where
+  parseJSON = withText "PaymentMethod.CardType" $ eitherFail . tryInto @CardType
+
+instance TryFrom Text CardType where
+  tryFrom = maybeTryFrom $ \cardType -> case cardType of
+    "American Express" -> Just AmericanExpress
+    "Dankort" -> Just Dankort
+    "Diners Club" -> Just DinersClub
+    "Discover" -> Just Discover
+    "Forbrugsforeningen" -> Just Forbrugsforeningen
+    "JCB" -> Just JCB
+    "Laser" -> Just Laser
+    "Maestro" -> Just Maestro
+    "MasterCard" -> Just MasterCard
+    "Test Card" -> Just TestCard
+    "Union Pay" -> Just UnionPay
+    "Unknown" -> Just Unknown
+    "Visa" -> Just Visa
+    "Tarjeta Naranj" -> Just TarjetaNaranj
+    _ -> Nothing
+
+instance From CardType Text where
+  from cardType = case cardType of
+    AmericanExpress -> "American Express"
+    Dankort -> "Dankort"
+    DinersClub -> "Diners Club"
+    Discover -> "Discover"
+    Forbrugsforeningen -> "Forbrugsforeningen"
+    JCB -> "JCB"
+    Laser -> "Laser"
+    Maestro -> "Maestro"
+    MasterCard -> "MasterCard"
+    TestCard -> "Test Card"
+    UnionPay -> "Union Pay"
+    Unknown -> "Unknown"
+    Visa -> "Visa"
+    TarjetaNaranj -> "Tarjeta Naranj"

--- a/library/Recurly/V3/API/Types/BillingInfo/PaymentMethod/Object.hs
+++ b/library/Recurly/V3/API/Types/BillingInfo/PaymentMethod/Object.hs
@@ -1,0 +1,69 @@
+module Recurly.V3.API.Types.BillingInfo.PaymentMethod.Object where
+
+import Recurlude
+
+data Object
+  = Amazon
+  | AmazonBillingAgreement
+  | ApplePay
+  | BankAccountInfo
+  | Check
+  | CreditCard
+  | Eft
+  | GatewayToken
+  | IbanBankAccount
+  | MoneyOrder
+  | Other
+  | Paypal
+  | PaypalBillingAgreement
+  | Roku
+  | Sepadirectdebit
+  | WireTransfer
+  | BraintreeVZero
+
+instance ToJSON Object where
+  toJSON = toJSON . into @Text
+
+instance FromJSON Object where
+  parseJSON = withText "PaymentMethod.Object" $ eitherFail . tryInto @Object
+
+instance TryFrom Text Object where
+  tryFrom = maybeTryFrom $ \object -> case object of
+    "amazon" -> Just Amazon
+    "amazon_billing_agreement" -> Just AmazonBillingAgreement
+    "apple_pay" -> Just ApplePay
+    "bank_account_info" -> Just BankAccountInfo
+    "check" -> Just Check
+    "credit_card" -> Just CreditCard
+    "eft" -> Just Eft
+    "gateway_token" -> Just GatewayToken
+    "iban_bank_account" -> Just IbanBankAccount
+    "money_order" -> Just MoneyOrder
+    "other" -> Just Other
+    "paypal" -> Just Paypal
+    "paypal_billing_agreement" -> Just PaypalBillingAgreement
+    "roku" -> Just Roku
+    "sepadirectdebit" -> Just Sepadirectdebit
+    "wire_transfer" -> Just WireTransfer
+    "braintree_v_zero" -> Just BraintreeVZero
+    _ -> Nothing
+
+instance From Object Text where
+  from object = case object of
+    Amazon -> "amazon"
+    AmazonBillingAgreement -> "amazon_billing_agreement"
+    ApplePay -> "apple_pay"
+    BankAccountInfo -> "bank_account_info"
+    Check -> "check"
+    CreditCard -> "credit_card"
+    Eft -> "eft"
+    GatewayToken -> "gateway_token"
+    IbanBankAccount -> "iban_bank_account"
+    MoneyOrder -> "money_order"
+    Other -> "other"
+    Paypal -> "paypal"
+    PaypalBillingAgreement -> "paypal_billing_agreement"
+    Roku -> "roku"
+    Sepadirectdebit -> "sepadirectdebit"
+    WireTransfer -> "wire_transfer"
+    BraintreeVZero -> "braintree_v_zero"


### PR DESCRIPTION
Story details: https://app.shortcut.com/itprotv/story/104787

In order to make this route move happen, we need to add the billing info call to Recurly. Here is the documentation for the route added: https://developers.recurly.com/api/v2021-02-25/index.html#operation/get_billing_info

---

- [ ] I manually tested the code locally to make sure that it works.
- [ ] If there is documentation, I made sure it's accurate and up to date.
- [ ] If possible, I wrote automated tests for the new behavior.
