### PR TITLE
Allow for multiple billing results

### DIFF
--- a/library/Recurly/V3/API/Account.hs
+++ b/library/Recurly/V3/API/Account.hs
@@ -28,6 +28,15 @@ getAccountBillingInfo accountCode = Recurly.liftRecurly $ do
     ["accounts", into @PathPiece.PathPiece accountCode, "billing_info"]
   RecurlyApi.sendRequest request
 
+getAccountBillingInfos
+  :: Recurly.MonadRecurly m
+  => Account.Code
+  -> m (Client.Response (Either RecurlyException [BillingInfo]))
+getAccountBillingInfos accountCode = Recurly.liftRecurly $ do
+  request <- RecurlyApi.makeRequest
+    ["accounts", into @PathPiece.PathPiece accountCode, "billing_info"]
+  RecurlyApi.sendRequestList request
+
 getAccountSubscriptions
   :: Recurly.MonadRecurly m
   => Account.Code


### PR DESCRIPTION
Story details: https://app.shortcut.com/itprotv/story/108312

Trying to allow for no downtime, so I'm creating duplication for the list return, and once I have a PR for consumer web that is deployed that accounts for multiple billings, I will go back in and delete the single return function. I'm doing this same duplication in smurf with the routes.

---

- [ ] I manually tested the code locally to make sure that it works.
- [ ] If there is documentation, I made sure it's accurate and up to date.
- [ ] If possible, I wrote automated tests for the new behavior.
