### PR TITLE
Fix Billing Info Return

### DIFF
--- a/library/Recurly/V3/API/Types/BillingInfo/PaymentMethod.hs
+++ b/library/Recurly/V3/API/Types/BillingInfo/PaymentMethod.hs
@@ -11,10 +11,10 @@ import qualified Recurly.V3.API.Types.BillingInfo.PaymentMethod.Object as Paymen
 
 data PaymentMethod = PaymentMethod
   { object :: PaymentMethod.Object
-  , cardType :: Mayb PaymentMethod.CardType
-  , lastFour :: Mayb Text
-  , month :: Mayb Integer
-  , year :: Mayb Integer
+  , cardType :: Maybe PaymentMethod.CardType
+  , lastFour :: Maybe Text
+  , month :: Maybe Integer
+  , year :: Maybe Integer
   , payPalBillingAgreementId :: Maybe Text
   }
   deriving (Eq, Show)

--- a/library/Recurly/V3/API/Types/BillingInfo/PaymentMethod.hs
+++ b/library/Recurly/V3/API/Types/BillingInfo/PaymentMethod.hs
@@ -11,10 +11,10 @@ import qualified Recurly.V3.API.Types.BillingInfo.PaymentMethod.Object as Paymen
 
 data PaymentMethod = PaymentMethod
   { object :: PaymentMethod.Object
-  , cardType :: PaymentMethod.CardType
-  , lastFour :: Text
-  , month :: Integer
-  , year :: Integer
+  , cardType :: Mayb PaymentMethod.CardType
+  , lastFour :: Mayb Text
+  , month :: Mayb Integer
+  , year :: Mayb Integer
   , payPalBillingAgreementId :: Maybe Text
   }
   deriving (Eq, Show)
@@ -22,9 +22,9 @@ data PaymentMethod = PaymentMethod
 instance FromJSON PaymentMethod where
   parseJSON = withObject "PaymentMethod" $ \obj -> do
     object <- aesonRequired obj "object"
-    cardType <- aesonRequired obj "card_type"
-    lastFour <- aesonRequired obj "last_four"
-    month <- aesonRequired obj "exp_month"
-    year <- aesonRequired obj "exp_year"
+    cardType <- aesonOptional obj "card_type"
+    lastFour <- aesonOptional obj "last_four"
+    month <- aesonOptional obj "exp_month"
+    year <- aesonOptional obj "exp_year"
     payPalBillingAgreementId <- aesonOptional obj "billing_agreement_id"
     pure PaymentMethod { object, cardType, lastFour, month, year, payPalBillingAgreementId }


### PR DESCRIPTION
Story details: https://app.shortcut.com/itprotv/story/108384

Sadly the documentation in Recurly doesn't say which types show up for which billing, so these should all be `maybe` types to accommodate card and PayPal users.

---

- [ ] I manually tested the code locally to make sure that it works.
- [ ] If there is documentation, I made sure it's accurate and up to date.
- [ ] If possible, I wrote automated tests for the new behavior.
